### PR TITLE
Put back the root pom.xml

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,14 +20,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <groupId>org.jboss.spec.javax.management.j2ee</groupId>
+        <artifactId>jboss-j2eemgmt-api_1.1_spec-parent</artifactId>
+        <version>2.0.0.Final-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.jboss.spec.javax.management.j2ee</groupId>
     <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
-    <version>2.0.0.Final-SNAPSHOT</version>
 
     <properties>
         <non.final>false</non.final>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>35</version>
+    </parent>
+
+    <groupId>org.jboss.spec.javax.management.j2ee</groupId>
+    <artifactId>jboss-j2eemgmt-api_1.1_spec-parent</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Jboss Jakarta EE Management API</name>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <modules>
+        <module>api</module>
+    </modules>
+
+    <licenses>
+        <license>
+            <name>EPL 2.0</name>
+            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GPL2 w/ CPE</name>
+            <url>https://www.gnu.org/software/classpath/license.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+</project>


### PR DESCRIPTION
For convenience, it allows to release the project from the root
directory.
The root POM itself is not deployed during the release process.