### PR TITLE
Upgrade EJB API 3.2 spec

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
-            <version>1.0.2.Final</version>
+            <version>2.0.0.Final</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* upgrade to org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec:2.0.0.Final

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>